### PR TITLE
update: fix the navigation from the preferences menu

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -126,7 +126,11 @@ export default function App(): React.ReactElement {
         <Stack.Screen
           name="Home"
           component={HomeScreen}
-          options={{ title: 'Sayvr' }}
+          options={({ navigation }) => ({
+            title: 'Sayvr',
+            headerLeft: () => null, // This removes the back button
+            gestureEnabled: false // This disables the swipe back gesture
+          })}
         />
         <Stack.Screen
           name="Preferences"

--- a/src/screens/PreferenceScreen.tsx
+++ b/src/screens/PreferenceScreen.tsx
@@ -87,7 +87,7 @@ const PreferencesScreen: React.FC<Props> = ({ navigation }) => {
         [
           {
             text: 'OK',
-            onPress: () => navigation.navigate('Home')
+            onPress: () => navigation.replace('Home')
           }
         ]
       );


### PR DESCRIPTION
## Updates

Preferences screen when you would update the preferences and save the settings it would navigate to the home screen but the top left would display a way to go back to the preferences screen. Updated the navigation so it would have this problem. 