### PR TITLE
update: disabled the back button for flyer results and meal plan gene…

### DIFF
--- a/src/screens/FlyerResultsScreen.tsx
+++ b/src/screens/FlyerResultsScreen.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   StyleSheet,
   ScrollView,
   SafeAreaView,
   Alert,
+  BackHandler,
 } from 'react-native';
 import { StackScreenProps } from '@react-navigation/stack';
 import { RootStackParamList, FlyerData, Product } from '../../App';
@@ -28,6 +29,24 @@ const FlyerResultsScreen: React.FC<Props> = ({ route, navigation }) => {
   const [editingProduct, setEditingProduct] = useState<{ product: Product, flyerIndex: number, productIndex: number } | null>(null);
   const [showAddProductModal, setShowAddProductModal] = useState(false);
   const [selectedFlyerIndex, setSelectedFlyerIndex] = useState(0);
+  
+  // Disable back navigation to prevent API overuse
+  useEffect(() => {
+    // Disable hardware back button
+    const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+      return true; // Prevent default back behavior
+    });
+    
+    // Disable navigation back gesture and header back button
+    navigation.setOptions({
+      headerLeft: () => null,
+      gestureEnabled: false
+    });
+    
+    return () => {
+      backHandler.remove();
+    };
+  }, [navigation]);
 
   // Form state for editing/adding products
   const [editForm, setEditForm] = useState({

--- a/src/screens/MealPlanScreen.tsx
+++ b/src/screens/MealPlanScreen.tsx
@@ -7,6 +7,7 @@ import {
   ActivityIndicator,
   View,
   Text,
+  BackHandler,
 } from 'react-native';
 import { StackScreenProps } from '@react-navigation/stack';
 import { RootStackParamList, MealPlan, Meal, SerializableMealPlan } from '../../App';
@@ -54,6 +55,27 @@ const MealPlanScreen: React.FC<Props> = ({ route, navigation }) => {
   const [showWeeklyView, setShowWeeklyView] = useState(true);
   const [selectedDayMeals, setSelectedDayMeals] = useState<Meal[]>([]);
   const [selectedDayIndex, setSelectedDayIndex] = useState<number>(0);
+  
+  // Disable back navigation to prevent API overuse
+  useEffect(() => {
+    // Only disable back navigation if coming from camera flow
+    if (source === 'camera') {
+      // Disable hardware back button
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        return true; // Prevent default back behavior
+      });
+      
+      // Disable navigation back gesture and header back button
+      navigation.setOptions({
+        headerLeft: () => null,
+        gestureEnabled: false
+      });
+      
+      return () => {
+        backHandler.remove();
+      };
+    }
+  }, [navigation, source]);
   
   // Grocery list state
   const [activeTab, setActiveTab] = useState<'meals' | 'grocery'>('meals');


### PR DESCRIPTION
## What's changed
Now users can't go back a screen after the flyer results and meal plan results unless they use the scan again button or the new plan button. 

## Why it was implemented
before I could just accidentally click on the previous screen button and it would go back to the previous screen while generating or after finish generating losing the data that was produced now with this there shouldn't be any human intervention.

## Note
At some point will need to add a limiter to how many times the api can be called per unique account it case of API over usage.